### PR TITLE
Don't treat all unrecognized destinations as a file

### DIFF
--- a/src/Logging/Settings.hs
+++ b/src/Logging/Settings.hs
@@ -64,7 +64,12 @@ readLogDestination :: String -> Either String LogDestination
 readLogDestination = \case
   "stdout" -> Right LogDestinationStdout
   "stderr" -> Right LogDestinationStderr
-  x -> Right $ LogDestinationFile x
+  ('@' : path) -> Right $ LogDestinationFile path
+  x ->
+    Left
+      $ "Invalid log destination "
+      <> x
+      <> ", must be stdout, stderr, or @{path}"
 
 data LogFormat
     = LogFormatJSON

--- a/src/Logging/Settings/Env.hs
+++ b/src/Logging/Settings/Env.hs
@@ -3,9 +3,9 @@
 -- - @LOG_LEVEL@: a known log level (case insensitive). Unrecognized values will
 --   become 'LevelOther' (preserving case).
 --
--- - @LOG_DESTINATION@: the string @stderr@ or @stdout@ (case sensitive).
---   Unrecognized values will be treated as a file path destination (without
---   checking if it exists).
+-- - @LOG_DESTINATION@: the string @stderr@ or @stdout@ (case sensitive), or
+--   @\@{path}@ to log to the file at @path@. Unrecognized values will produce
+--   and error.
 --
 -- - @LOG_FORMAT@: the string @tty@ or @json@. Unrecognized values will produce
 --   an error.


### PR DESCRIPTION
A common typo (e.g. "STDOUT") should result in a failure to start, not
logging to a file you don't realize. Prefixing file arguments with "@"
is a common convention (see curl) we can leverage.

We do not support "@-" to mean stdout, though we easily could.
